### PR TITLE
Fix tooltip persistence on navigation by adding close-on-back and using router-link

### DIFF
--- a/web/client/src/views/Jobs.vue
+++ b/web/client/src/views/Jobs.vue
@@ -29,11 +29,9 @@
       </template>
 
       <template #item.name="{ item }">
-        <v-tooltip top>
+        <v-tooltip top close-on-back="true">
           <template #activator="{ on, attrs }">
-            <span v-bind="attrs" v-on="on"
-              ><a :href="`/job/${item._id}`">{{ item.name }}</a></span
-            >
+            <span v-bind="attrs" v-on="on"><router-link :to="`/job/${item._id}`" v-bind="attrs">{{ item.name }}</router-link></span>
           </template>
           <span>
             Container: {{ item.imageUri }}<br />


### PR DESCRIPTION
### Problem:
The tooltip remained visible after navigating away from the page and returning via the browser's back button.

### Solution:
- Added `close-on-back="true"` to the tooltip component.
- Replaced the native `<a>` tag with `<router-link>` for proper Vue Router integration.
